### PR TITLE
Allows entities to be extended by a custom parent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/dotenv": "^4.4",
         "symfony/flex": "^1.7",
         "symfony/web-profiler-bundle": "^4.4",
-        "phpmd/phpmd": "@stable"
+        "phpmd/phpmd": "@stable",
+        "http-interop/http-factory-guzzle": "^1.2"
     },
     "prefer-stable": true,
     "autoload": {

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -39,6 +39,7 @@ class Message implements ResourceInterface, TimestampableInterface, ToggleableIn
     }
 
     protected ?int $id = null;
+
     protected bool $customersOnly = false;
 
     protected ?string $name = null;

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -46,13 +46,13 @@ class Message implements ResourceInterface, TimestampableInterface, ToggleableIn
     protected ?string $description = null;
 
     /** @var Collection<int, ChannelInterface> */
-    private Collection $channels;
+    protected Collection $channels;
 
-    private ?string $templateHtml = null;
+    protected ?string $templateHtml = null;
 
-    private ?DateTimeInterface $fromDate = null;
+    protected ?DateTimeInterface $fromDate = null;
 
-    private ?DateTimeInterface $toDate = null;
+    protected ?DateTimeInterface $toDate = null;
 
     /**
      * Message constructor.

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -16,8 +16,6 @@ namespace MonsieurBiz\SyliusAlertMessagePlugin\Entity;
 use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
@@ -28,10 +26,6 @@ use Sylius\Component\Resource\Model\ToggleableTrait;
 use Sylius\Component\Resource\Model\TranslatableInterface;
 use Sylius\Component\Resource\Model\TranslatableTrait;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="mbiz_alert_message")
- */
 class Message implements ResourceInterface, TimestampableInterface, ToggleableInterface, TranslatableInterface, Timestampable
 {
     use TimestampableTrait;
@@ -44,81 +38,21 @@ class Message implements ResourceInterface, TimestampableInterface, ToggleableIn
         getTranslation as private doGetTranslation;
     }
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
-    private $id;
+    protected ?int $id = null;
+    protected bool $customersOnly = false;
 
-    /**
-     * @var bool
-     * @ORM\Column(type="boolean", options={"default"=true})
-     */
-    protected $enabled = true;
+    protected ?string $name = null;
 
-    /**
-     * @var bool
-     * @ORM\Column(name="customers_only", type="boolean", options={"default"=false})
-     */
-    protected $customersOnly = false;
+    protected ?string $description = null;
 
-    /**
-     * @var string|null
-     * @ORM\Column(type="string")
-     */
-    protected $name;
+    /** @var Collection<int, ChannelInterface> */
+    private Collection $channels;
 
-    /**
-     * @var string|null
-     * @ORM\Column(type="string", nullable=true)
-     */
-    protected $description;
+    private ?string $templateHtml = null;
 
-    /**
-     * @var Collection<int, ChannelInterface>
-     * @ORM\ManyToMany(targetEntity="\Sylius\Component\Core\Model\ChannelInterface")
-     * @ORM\JoinTable(
-     *     name="mbiz_alert_message_channels",
-     *     joinColumns={@ORM\JoinColumn(name="message_id", referencedColumnName="id")},
-     *     inverseJoinColumns={@ORM\JoinColumn(name="channel_id", referencedColumnName="id")}
-     * )
-     */
-    private $channels;
+    private ?DateTimeInterface $fromDate = null;
 
-    /**
-     * @var DateTimeInterface|null
-     * @ORM\Column(name="created_at", type="datetime_immutable")
-     * @Gedmo\Timestampable(on="create")
-     */
-    protected $createdAt;
-
-    /**
-     * @var DateTimeInterface|null
-     * @ORM\Column(name="updated_at", type="datetime")
-     * @Gedmo\Timestampable(on="update")
-     */
-    protected $updatedAt;
-
-    /**
-     * @var string|null
-     * @ORM\Column(name="template_html", type="text", nullable=true)
-     */
-    private $templateHtml;
-
-    /**
-     * @var DateTimeInterface|null
-     * @ORM\Column(name="from_date", type="datetime", nullable=true)
-     */
-    private $fromDate;
-
-    /**
-     * @var DateTimeInterface|null
-     * @ORM\Column(name="to_date", type="datetime", nullable=true)
-     */
-    private $toDate;
+    private ?DateTimeInterface $toDate = null;
 
     /**
      * Message constructor.

--- a/src/Entity/MessageTranslation.php
+++ b/src/Entity/MessageTranslation.php
@@ -20,9 +20,9 @@ class MessageTranslation extends AbstractTranslation implements ResourceInterfac
 {
     protected ?int $id = null;
 
-    private ?string $title = null;
+    protected ?string $title = null;
 
-    private ?string $message = null;
+    protected ?string $message = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/MessageTranslation.php
+++ b/src/Entity/MessageTranslation.php
@@ -13,37 +13,16 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusAlertMessagePlugin\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Resource\Model\AbstractTranslation;
 use Sylius\Component\Resource\Model\ResourceInterface;
-use Sylius\Component\Resource\Model\TranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="mbiz_alert_message_translation")
- */
-class MessageTranslation extends AbstractTranslation implements TranslationInterface, ResourceInterface
+class MessageTranslation extends AbstractTranslation implements ResourceInterface
 {
-    /**
-     * @var int|null
-     *
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
-    private $id;
+    protected ?int $id = null;
 
-    /**
-     * @var string|null
-     * @ORM\Column(type="string", nullable=true)
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string|null
-     * @ORM\Column(type="text")
-     */
-    private $message;
+    private ?string $message = null;
 
     public function getId(): ?int
     {

--- a/src/Resources/config/doctrine/Message.orm.xml
+++ b/src/Resources/config/doctrine/Message.orm.xml
@@ -42,7 +42,7 @@
             <gedmo:timestampable on="create"/>
         </field>
 
-        <field name="updatedAt" column="updated_at" type="datetime_immutable">
+        <field name="updatedAt" column="updated_at" type="datetime">
             <gedmo:timestampable on="update"/>
         </field>
 

--- a/src/Resources/config/doctrine/Message.orm.xml
+++ b/src/Resources/config/doctrine/Message.orm.xml
@@ -8,7 +8,7 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <mapped-superclass name="\MonsieurBiz\SyliusAlertMessagePlugin\Entity\Message" table="mbiz_alert_message">
+    <mapped-superclass name="MonsieurBiz\SyliusAlertMessagePlugin\Entity\Message" table="mbiz_alert_message">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>

--- a/src/Resources/config/doctrine/Message.orm.xml
+++ b/src/Resources/config/doctrine/Message.orm.xml
@@ -38,15 +38,15 @@
             </join-table>
         </many-to-many>
 
-        <field name="createdAt" column="created_at" type="datetime">
+        <field name="createdAt" column="created_at" type="datetime_immutable">
             <gedmo:timestampable on="create"/>
         </field>
 
-        <field name="updatedAt" column="updated_at" type="datetime">
+        <field name="updatedAt" column="updated_at" type="datetime_immutable">
             <gedmo:timestampable on="update"/>
         </field>
 
-        <field name="templateHtml" column="template_html" type="string" nullable="true" />
+        <field name="templateHtml" column="template_html" type="text" nullable="true" />
         <field name="fromDate" column="from_date" type="datetime" nullable="true" />
         <field name="toDate" column="to_date" type="datetime" nullable="true" />
     </mapped-superclass>

--- a/src/Resources/config/doctrine/Message.orm.xml
+++ b/src/Resources/config/doctrine/Message.orm.xml
@@ -14,13 +14,13 @@
         </id>
         <field name="enabled" column="enabled" type="boolean">
             <options>
-                <option name="default">true</option>
+                <option name="default">1</option>
             </options>
         </field>
 
         <field name="customersOnly" column="customers_only" type="boolean">
             <options>
-                <option name="default">false</option>
+                <option name="default">0</option>
             </options>
         </field>
 

--- a/src/Resources/config/doctrine/Message.orm.xml
+++ b/src/Resources/config/doctrine/Message.orm.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping
+    xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+    xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+
+    <mapped-superclass name="\MonsieurBiz\SyliusAlertMessagePlugin\Entity\Message" table="mbiz_alert_message">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+        <field name="enabled" column="enabled" type="boolean">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+
+        <field name="customersOnly" column="customers_only" type="boolean">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
+        <field name="name" column="name" type="string" />
+        <field name="description" column="description" type="string" nullable="true" />
+
+        <many-to-many field="channels" target-entity="Sylius\Component\Core\Model\ChannelInterface">
+            <join-table name="mbiz_alert_message_channels">
+                <join-columns>
+                    <join-column name="message_id" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="channel_id" />
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+
+        <field name="updatedAt" column="updated_at" type="datetime">
+            <gedmo:timestampable on="update"/>
+        </field>
+
+        <field name="templateHtml" column="template_html" type="string" nullable="true" />
+        <field name="fromDate" column="from_date" type="datetime" nullable="true" />
+        <field name="toDate" column="to_date" type="datetime" nullable="true" />
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/MessageTranslation.orm.xml
+++ b/src/Resources/config/doctrine/MessageTranslation.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping
+    xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+
+    <mapped-superclass name="\MonsieurBiz\SyliusAlertMessagePlugin\Entity\MessageTranslation" table="mbiz_alert_message_translation">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="title" column="title" type="string" nullable="true" />
+        <field name="message" column="message" type="text" />
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/MessageTranslation.orm.xml
+++ b/src/Resources/config/doctrine/MessageTranslation.orm.xml
@@ -7,7 +7,7 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <mapped-superclass name="\MonsieurBiz\SyliusAlertMessagePlugin\Entity\MessageTranslation" table="mbiz_alert_message_translation">
+    <mapped-superclass name="MonsieurBiz\SyliusAlertMessagePlugin\Entity\MessageTranslation" table="mbiz_alert_message_translation">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>


### PR DESCRIPTION
This PR is allowing to extends the 2 Doctrine entities available.

- [x] Swicth to XML mapping (not required but it will if this plugin wants to support PHP 8.1 one day).
- [x] Make properties `protected` instead of `private`.
- [x] Switch from Doctrine Table to MappedSuperClass to allow overrides.
- [ ] Add overrided entities to the flex recipe to test the override ?

Note: I saw some entity properties are nullable but they aren't when you look at the database schema definition.